### PR TITLE
Remove duplicate "the" from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/technical.md
+++ b/.github/ISSUE_TEMPLATE/technical.md
@@ -2,7 +2,7 @@
 name: Tech
 about: A task, enhancement idea, or bug report related to the technical aspects of
   the project.
-title: Description of the the issue
+title: Description of the issue
 labels: ''
 assignees: ''
 


### PR DESCRIPTION
Noticed while filing https://github.com/sigstore/sigstore-website/issues/26, ironically enough.