### PR TITLE
Remove default titles for issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,7 +1,6 @@
 ---
 name: Bug
 about: Something wrong with the project? Report it here!
-title: Concise description of the bug
 labels: 'bug'
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/issue-or-enhancement.md
+++ b/.github/ISSUE_TEMPLATE/issue-or-enhancement.md
@@ -2,7 +2,6 @@
 name: Issue or Enhancement
 about: A task or enhancement idea related to the technical aspects of
   the project.
-title: Concise description of the issue
 labels: 'enhancement'
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/questions.md
+++ b/.github/ISSUE_TEMPLATE/questions.md
@@ -1,7 +1,6 @@
 ---
 name: Question
 about: Have a question about the project? Ask it here!
-title: What are you wondering about?
 labels: question
 assignees: ''
 


### PR DESCRIPTION
Signed-off-by: Jason Hall <jason@chainguard.dev>

Providing titles in the issue templates may encourage folks to unwittingly file issues with those default titles intact (see https://github.com/sigstore/cosign/issues/1882). This requires a project maintainer to re-title the issue.

If the issue template doesn't have a pre-filled title, the person filing the issue has to provide one themselves before being able to submit the issue. The prefilled issue body already prompts for this information inside of `<!-- -->`s.